### PR TITLE
[9주차] JAVA: 아이템 줍기

### DIFF
--- a/programmers/sung-silver/dfs-bfs/아이템_줍기.java
+++ b/programmers/sung-silver/dfs-bfs/아이템_줍기.java
@@ -1,0 +1,69 @@
+import java.util.*;
+class Solution {
+    static class Rect{
+		int x1,x2,y1,y2;
+		
+		public Rect(int x1, int y1, int x2, int y2) {
+			this.x1 =x1;
+			this.y1 =y1;
+			this.x2 =x2;
+			this.y2 =y2;
+		}
+	}
+	static int x,y;
+	static List<Rect> rectList;
+	static int[] dx = {-1, 1, 0, 0};
+	static int[] dy = {0, 0, -1, 1};
+    public int solution(int[][] rectangle, int characterX, int characterY, int itemX, int itemY) {
+        int answer = 0;
+		int[][] map = new int[102][102];
+        rectList = new ArrayList<>();
+        for(int i=0; i<rectangle.length; i++) {
+        	int sx = rectangle[i][0]*2;
+        	int sy = rectangle[i][1]*2;
+        	int ex = rectangle[i][2]*2;
+        	int ey = rectangle[i][3]*2;
+        	
+        	for(int y=sy; y<=ey; y++) {
+        		for(int x=sx; x<=ex; x++) {
+        			map[y][x] = -1;
+        		}
+        	}
+        	rectList.add(new Rect(sx,sy,ex,ey));
+        }
+
+        answer= bfs(map, characterX*2, characterY*2, itemX*2, itemY*2);
+        return answer;
+    }
+    static int bfs(int[][] map, int x, int y, int tx, int ty) {
+		Queue<int[]> q = new LinkedList<>();
+		q.add(new int[] {x, y, 1});
+		map[y][x] = 1;
+		while(!q.isEmpty()) {
+			int[] p = q.poll();
+			int px = p[0];
+			int py = p[1];
+			int move = p[2];
+			
+			if(px == tx && py == ty) {
+				return (move/2);
+			}
+			
+			for(int i=0; i<4; i++) {
+				int nx = px + dx[i];
+				int ny = py + dy[i];
+				if(map[ny][nx] < 0 && isBoundary(nx,ny)) {
+					map[ny][nx] = move+1;
+					q.add(new int[] {nx, ny, move+1});
+				}
+			}
+		}
+		return -1;
+	}
+    static boolean isBoundary(int x, int y) {
+		for(Rect r : rectList) {
+			if(r.x1 < x && r.y1 <y && r.x2 > x && r.y2 > y) return false;
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
## 1️⃣ 어떤 문제인가요?
- 아이템 줍기: https://school.programmers.co.kr/learn/courses/30/lessons/87694

## 2️⃣ 어떻게 문제를 분석했나요?
- 경계만 이동이 가능하도록하여 목적지까지 가는 최소 찾기

## 3️⃣ 어떻게 문제를 풀었나요?
### 문제는 어떤 유형인가요?
- BFS

### 어떤 방식으로 풀이할건가요?
- 주어진 사각형의 좌표를 2배로 크게만든 다음 list와 이차원 배열 맵에 -1로 표시해준다.
  - sx *= 2, sy *= 2;
  - ex *= 2, ey *= 2;
- BFS 탐색을 통해 출발점에서 목적 지점으로 가는 최단 경로를 찾는다. bfs(map, characterX*2, characterY*2, itemX*2, itemY*2);
  - 입력된 사각형의 바운더리만 이동이 가능하게 조건을 설정한다.
  - 목적지점(tx, ty)에 도착했으면 기존에 맵을 2배로 늘렸기 때문에  2로 나눠준 값을 출력한다. return (move/2);

### 시간복잡도 공간복잡도를 어떻게 고려했나요?
- 시간복잡도 : O(N^2)
- 공간복잡도 : O(N^2)


## 4️⃣ 아쉬웠던 점
- 많은 풀이를 참고할 때 왜 맵을 두배로 늘려야하는가에 대해 이해하는데 시간이 오래걸림!


## 5️⃣ 인증
<img width="1318" alt="image" src="https://github.com/alcohol-study/2024-programmers/assets/81363864/8da6d114-ecc8-40ba-9123-53a51a7f083e">

