### PR TITLE
[21주차] SQL: 조회수가 가장 많은 중고거래 게시판의 첨부파일 조회하기

### DIFF
--- a/programmers/sql/sung-silver/조회수가_가장_많은_중고거래_게시판의_첨부파일_조회하기.sql
+++ b/programmers/sql/sung-silver/조회수가_가장_많은_중고거래_게시판의_첨부파일_조회하기.sql
@@ -1,0 +1,7 @@
+SELECT concat('/home/grep/src/',board_id,'/',file_id,file_name,file_ext) as FILE_PATH
+FROM used_goods_file
+WHERE board_id = (SELECT board_id 
+                   FROM USED_GOODS_BOARD
+                   ORDER BY views desc
+                  LIMIT 1)
+ORDER BY file_id DESC;


### PR DESCRIPTION
## 1️⃣ 어떤 문제인가요?
- 조회수가 가장 많은 중고거래 게시판의 첨부파일 조회하기

## 2️⃣ 어떻게 문제를 분석했나요?
- limit으로 조회수가 가장 많은 게시글 id를 가져와서 찾는다

## 3️⃣ 어떻게 문제를 풀었나요?
### 문제는 어떤 유형인가요?
- limit?

### 어떤 방식으로 풀이할건가요?
- limit 1로 가장 조회수가 많은 게시글을 찾아 그 게시글의 파일 경로들을 출력



## 4️⃣ 아쉬웠던 점



## 5️⃣ 인증
<img width="1518" alt="스크린샷 2024-07-28 오후 10 14 23" src="https://github.com/user-attachments/assets/edc2c8bd-871c-43ce-8fa4-7c2ff887673e">
